### PR TITLE
stock_picking_invoicing_unified: for a return, qty should be < 0, not the price (plus some other details)

### DIFF
--- a/stock_picking_invoicing_unified/README.rst
+++ b/stock_picking_invoicing_unified/README.rst
@@ -6,10 +6,10 @@
 Stock Picking Invoicing Unified
 ===============================
 
-Odoo allows to select several pickings and click on "Create Draft Invoices"
-option for creating the corresponding invoice(s) depending if you have
-selected several partners and if you have marked the "Group by partner"
-check.
+Odoo allows to select several pickings and click on *Create Draft Invoices*
+option to create the corresponding invoice(s)/refund(s). If you have
+selected several partners and you have checked the option *Group by partner*,
+it will create a single invoice or refund per partner.
 
 But it only takes into account the first picking for selecting the type of the
 invoice you are going to create (customer/supplier invoice/refund), mixing all
@@ -17,11 +17,13 @@ the lines on it. And not only that: if you have returned pickings, the returned
 quantities are summed to the rest, instead of decreasing the amount to invoice,
 which is the common practise when you have some returns.
 
-This module overpasses this limitation, allowing to invoice them all together
-without having to worry about that, and also having the extra feature of
-reducing the amount in the invoice when you have delivered or received goods
-and some of them (or previous ones) have been returned, instead of needing
-to create 2 invoices and to conciliate them for the final/real amount.
+This module fixes this problem, allowing to invoice them all together:
+if you have delivered and received goods for the same customer and you
+have checked the option *Group by partner*, you will have a single
+invoice with the goods delivered and received and the quantities of the
+goods received will be negative. So it will avoid you to send both an
+invoice and a refund to your customer and have to reconciliate them to
+compute the good residual amount.
 
 Usage
 =====

--- a/stock_picking_invoicing_unified/__openerp__.py
+++ b/stock_picking_invoicing_unified/__openerp__.py
@@ -5,6 +5,7 @@
 
 {
     "name": "Stock Picking Invoicing Unified",
+    "summary": "Create invoices/refunds from pickings of different types",
     "version": "8.0.1.0.0",
     'author': 'Serv. Tecnol. Avanzados - Pedro M. Baeza, '
               'AvanzOSC, '

--- a/stock_picking_invoicing_unified/models/stock_picking.py
+++ b/stock_picking_invoicing_unified/models/stock_picking.py
@@ -13,7 +13,7 @@ class StockMove(models.Model):
     def _get_invoice_line_vals(self, move, partner, inv_type):
         res = super(StockMove, self)._get_invoice_line_vals(move, partner,
                                                             inv_type)
-        # price to negative value
+        # negative value on quantity
         if ((inv_type == 'out_invoice' and
                 move.location_id.usage == 'customer') or
                 (inv_type == 'out_refund' and
@@ -22,5 +22,5 @@ class StockMove(models.Model):
                  move.location_dest_id.usage == 'supplier') or
                 (inv_type == 'in_refund' and
                  move.location_id.usage == 'supplier')):
-            res['price_unit'] *= -1
+            res['quantity'] *= -1
         return res

--- a/stock_picking_invoicing_unified/wizard/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing_unified/wizard/stock_invoice_onshipping.py
@@ -111,16 +111,17 @@ class StockInvoiceOnshipping(models.TransientModel):
     def get_split_pickings_nogrouped(self, pickings):
         sale_pickings = pickings.filtered(
             lambda x: x.picking_type_id.code == 'outgoing' and
-            x.move_lines[0].location_dest_id.usage == 'customer')
+            x.move_lines[:1].location_dest_id.usage == 'customer')
+        # use [:1] instead of [0] to avoid a errors on empty pickings
         sale_refund_pickings = pickings.filtered(
             lambda x: x.picking_type_id.code == 'incoming' and
-            x.move_lines[0].location_id.usage == 'customer')
+            x.move_lines[:1].location_id.usage == 'customer')
         purchase_pickings = pickings.filtered(
             lambda x: x.picking_type_id.code == 'incoming' and
-            x.move_lines[0].location_id.usage == 'supplier')
+            x.move_lines[:1].location_id.usage == 'supplier')
         purchase_refund_pickings = pickings.filtered(
             lambda x: x.picking_type_id.code == 'outgoing' and
-            x.move_lines[0].location_dest_id.usage == 'supplier')
+            x.move_lines[:1].location_dest_id.usage == 'supplier')
         return (sale_pickings, sale_refund_pickings, purchase_pickings,
                 purchase_refund_pickings)
 


### PR DESCRIPTION
When we take into account a return, the quantity should be negative, not the price !

Give default value to journals (to behave like the stock_account module on this point)
Replace [:1] by [0], to make it easier to read
Add summary key in **openerp**.py
Re-phrase some parts of README.rst
